### PR TITLE
Add read-aloud codex output for phonetic toolkit

### DIFF
--- a/README.md
+++ b/README.md
@@ -11,3 +11,103 @@ Visit our site:
 https://beblia.com
 God Bless.
 Thank you.
+
+## Phonetic trailing song toolkit
+
+This repository now also ships a lightweight phonetic analysis toolkit that can
+generate deterministic numeric signatures for any passage of text.  The core
+entry point is `phonetic_trailing_song_model.py` which exposes both a Python API
+and a command-line interface.
+
+### Command-line usage
+
+```
+python phonetic_trailing_song_model.py --title "Sample" samples.txt \
+  --compare-with reference.txt --compare-window-size 3 --emit-json
+```
+
+Key options:
+
+* `--seed-from` – supply a deterministic seed string (for example a title).
+* `--select-token` – print the slider/seed metrics for a specific token index.
+* `--no-report` and `--emit-json` – suppress the textual report and emit a JSON payload instead.
+* `--emit-data-bundle PATH` – create a machine-learning friendly bundle with prompts and completions.
+* `--language-code CODE` – force a specific language profile (otherwise the model auto-detects per token).
+* `--list-languages` – print the available language profiles (covering Latin, Greek, Cyrillic, Arabic, Hebrew, Devanagari, Hangul, and Kana scripts) and exit.
+
+Every textual report opens with a **silent writing title** section: for each
+language represented in the input the toolkit records the backwards (writing
+first) rendering of the title/tokens, along with an ASCII fallback and a
+deterministic seed.  This satisfies workflows that require phonetic ordering to
+be derived purely from the written form rather than spoken pronunciations.
+
+### Read-aloud codex
+
+The analyzer now emits a "cold start" read-aloud codex that breaks each token
+into syllable-like beats, calculates deterministic intensity levels, and
+produces dimmable sliders for narration tooling.  CLI reports list the top
+entries, while JSON outputs include per-syllable intensity, dim ratios, and
+primary/secondary emphasis markers so text-to-speech systems can start reading
+aloud immediately without additional calibration.
+
+### Knowledge base output
+
+Every run now produces a structured knowledge base that captures per-token
+signatures, repeating clusters, and aggregated "wisdom" insights.  The CLI
+report surfaces the top entries, while JSON exports and data bundles expose the
+full dataset for downstream storage engines or retrieval workflows.
+
+### HTTP API
+
+`phonetic_api.py` wraps the model in a tiny WSGI application.  Run it with the
+built-in server:
+
+```
+python phonetic_api.py --port 8080
+```
+
+POST JSON requests to `/analyze` with the following schema:
+
+```
+{
+  "title": "My Analysis",
+  "text": "Amazing grace how sweet the sound",
+  "reference_text": "Amazing grace a song of sound",
+  "language_code": "el",
+  "options": {
+    "include_bundle": true,
+    "window_size": 2,
+    "language_code": "el"
+  }
+}
+```
+
+The response contains the structured analysis and, if requested, a reusable data
+bundle.  The root metadata endpoint (`GET /`) now lists every built-in language
+profile so clients can select a compatible transliteration strategy ahead of
+time, and advertises the available capabilities (structured analysis, silent
+writing titles, read-aloud codex export, knowledge-base export, and bundle
+generation).
+
+### Language profiles
+
+The new `language_profiles.py` module centralises lightweight transliteration
+and detection heuristics for common scripts without relying on external
+packages.  Profiles currently cover English, Spanish, French, German,
+Portuguese, Greek, Russian/Ukrainian (Cyrillic), Arabic, Hebrew, Hindi
+(Devanagari), Korean (Hangul), and Japanese Kana.  Custom code can instantiate
+`LanguageProfileRegistry` directly or extend it with additional scripts before
+passing it into `PhoneticTrailingSongModel`.
+
+### Repository chunk planner
+
+`repo_chunk_planner.py` creates 3000-line iteration plans that cover the XML
+collection without leaving holes.  Example usage:
+
+```
+python repo_chunk_planner.py --include "*.xml" --chunk-size 3000 --export-json plan.json
+```
+
+The exported JSON documents the contiguous chunks, filler segments, and file
+statistics which can be shared alongside GitHub issues or pull requests when
+organising large review efforts.

--- a/README.md
+++ b/README.md
@@ -33,6 +33,7 @@ Key options:
 * `--no-report` and `--emit-json` – suppress the textual report and emit a JSON payload instead.
 * `--emit-data-bundle PATH` – create a machine-learning friendly bundle with prompts and completions.
 * `--language-code CODE` – force a specific language profile (otherwise the model auto-detects per token).
+* `--exclude-language CODE` – exclude specific language codes (for example, legacy or secret scripts) and fall back to the default profile while still noting the absence in the analysis output.
 * `--list-languages` – print the available language profiles (covering Latin, Greek, Cyrillic, Arabic, Hebrew, Devanagari, Hangul, and Kana scripts) and exit.
 
 Every textual report opens with a **silent writing title** section: for each
@@ -74,6 +75,7 @@ POST JSON requests to `/analyze` with the following schema:
   "text": "Amazing grace how sweet the sound",
   "reference_text": "Amazing grace a song of sound",
   "language_code": "el",
+  "exclude_languages": ["lin-a", "lin-b"],
   "options": {
     "include_bundle": true,
     "window_size": 2,

--- a/language_profiles.py
+++ b/language_profiles.py
@@ -1,0 +1,465 @@
+"""Language profile registry for phonetic analysis.
+
+This module provides lightweight transliteration and normalization helpers for a
+handful of common writing systems so the phonetic tooling can operate across
+multiple languages without external dependencies.  The goal is not to deliver
+perfect linguistic accuracy but to expose deterministic, script-aware fallbacks
+that cover the broad set of texts shipped with the repository.
+"""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+from typing import Callable, Dict, Iterable, List, Optional, Sequence, Tuple
+import unicodedata
+
+__all__ = [
+    "LanguageProfile",
+    "LanguageProfileRegistry",
+    "default_language_registry",
+]
+
+
+# ---------------------------------------------------------------------------
+# Utility helpers
+
+def _strip_accents(value: str) -> str:
+    normalized = unicodedata.normalize("NFKD", value)
+    return "".join(ch for ch in normalized if unicodedata.category(ch) != "Mn")
+
+
+def _ascii_fallback(value: str) -> str:
+    ascii_bytes = _strip_accents(value).encode("ascii", "ignore")
+    return ascii_bytes.decode("ascii", "ignore")
+
+
+def _transliterate_with_mapping(value: str, mapping: Dict[str, str]) -> str:
+    result: List[str] = []
+    normalized = unicodedata.normalize("NFKD", value)
+    for ch in normalized:
+        if unicodedata.category(ch) == "Mn":
+            continue
+        lower = ch.lower()
+        repl = mapping.get(lower)
+        if repl is None:
+            result.append(ch)
+            continue
+        if ch.isupper():
+            result.append(repl.upper())
+        else:
+            result.append(repl)
+    return "".join(result)
+
+
+def _normalize_lower(value: str) -> str:
+    return unicodedata.normalize("NFC", value).lower()
+
+
+# Script ranges are approximate buckets used for detection heuristics.
+_LATIN_RANGES: Tuple[Tuple[int, int], ...] = (
+    (0x0041, 0x024F),  # Basic + Extended Latin
+    (0x1E00, 0x1EFF),  # Latin Extended Additional
+)
+_GREEK_RANGES = ((0x0370, 0x03FF), (0x1F00, 0x1FFF))
+_CYRILLIC_RANGES = ((0x0400, 0x04FF), (0x0500, 0x052F))
+_ARABIC_RANGES = ((0x0600, 0x06FF), (0x0750, 0x077F))
+_DEVANAGARI_RANGES = ((0x0900, 0x097F),)
+_HEBREW_RANGES = ((0x0590, 0x05FF),)
+_HANGUL_RANGES = ((0xAC00, 0xD7AF),)
+_HIRAGANA_RANGES = ((0x3040, 0x309F),)
+_KATAKANA_RANGES = ((0x30A0, 0x30FF),)
+
+
+def _match_ratio(text: str, ranges: Sequence[Tuple[int, int]]) -> float:
+    total = 0
+    matches = 0
+    for ch in text:
+        if ch.isalpha():
+            total += 1
+            codepoint = ord(ch)
+            if any(start <= codepoint <= end for start, end in ranges):
+                matches += 1
+    if total == 0:
+        return 0.0
+    return matches / total
+
+
+@dataclass(frozen=True)
+class LanguageProfile:
+    code: str
+    name: str
+    description: str
+    script_ranges: Sequence[Tuple[int, int]]
+    romanizer: Callable[[str], str]
+    normalizer: Callable[[str], str] = _normalize_lower
+
+    def romanize(self, value: str) -> str:
+        return self.romanizer(value)
+
+    def normalize(self, value: str) -> str:
+        return self.normalizer(value)
+
+    def match_ratio(self, text: str) -> float:
+        return _match_ratio(text, self.script_ranges)
+
+
+class LanguageProfileRegistry:
+    """Registry handling detection and lookup for language profiles."""
+
+    def __init__(self, profiles: Optional[Iterable[LanguageProfile]] = None) -> None:
+        self._profiles: Dict[str, LanguageProfile] = {}
+        if profiles:
+            for profile in profiles:
+                self.register(profile)
+
+    # Public API ---------------------------------------------------------
+    def register(self, profile: LanguageProfile) -> None:
+        self._profiles[profile.code] = profile
+
+    def get(self, code: Optional[str]) -> Optional[LanguageProfile]:
+        if code is None:
+            return None
+        return self._profiles.get(code)
+
+    def list_profiles(self) -> List[LanguageProfile]:
+        return [self._profiles[key] for key in sorted(self._profiles)]
+
+    def detect(
+        self,
+        text: str,
+        *,
+        preferred: Optional[str] = None,
+        fallback: Optional[str] = "en",
+    ) -> Tuple[LanguageProfile, Dict[str, object]]:
+        if preferred:
+            profile = self.get(preferred)
+            if profile:
+                return profile, {
+                    "strategy": "override",
+                    "code": profile.code,
+                    "name": profile.name,
+                    "confidence": 1.0,
+                }
+        best_profile: Optional[LanguageProfile] = None
+        best_ratio = 0.0
+        for profile in self._profiles.values():
+            ratio = profile.match_ratio(text)
+            if ratio > best_ratio:
+                best_profile = profile
+                best_ratio = ratio
+        if best_profile and best_ratio >= 0.2:
+            return best_profile, {
+                "strategy": "detected",
+                "code": best_profile.code,
+                "name": best_profile.name,
+                "confidence": round(best_ratio, 3),
+            }
+        fallback_profile = self.get(fallback)
+        if fallback_profile:
+            return fallback_profile, {
+                "strategy": "fallback",
+                "code": fallback_profile.code,
+                "name": fallback_profile.name,
+                "confidence": round(best_ratio, 3),
+            }
+        # As a last resort pick the first available profile.
+        first_profile = next(iter(self._profiles.values()))
+        return first_profile, {
+            "strategy": "fallback",
+            "code": first_profile.code,
+            "name": first_profile.name,
+            "confidence": round(best_ratio, 3),
+        }
+
+
+# ---------------------------------------------------------------------------
+# Default registry configuration
+
+_GREEK_MAP = {
+    "α": "a",
+    "β": "b",
+    "γ": "g",
+    "δ": "d",
+    "ε": "e",
+    "ζ": "z",
+    "η": "e",
+    "θ": "th",
+    "ι": "i",
+    "κ": "k",
+    "λ": "l",
+    "μ": "m",
+    "ν": "n",
+    "ξ": "x",
+    "ο": "o",
+    "π": "p",
+    "ρ": "r",
+    "σ": "s",
+    "ς": "s",
+    "τ": "t",
+    "υ": "y",
+    "φ": "f",
+    "χ": "ch",
+    "ψ": "ps",
+    "ω": "o",
+}
+
+_CYRILLIC_MAP = {
+    "а": "a",
+    "б": "b",
+    "в": "v",
+    "г": "g",
+    "д": "d",
+    "е": "e",
+    "ё": "yo",
+    "ж": "zh",
+    "з": "z",
+    "и": "i",
+    "й": "y",
+    "к": "k",
+    "л": "l",
+    "м": "m",
+    "н": "n",
+    "о": "o",
+    "п": "p",
+    "р": "r",
+    "с": "s",
+    "т": "t",
+    "у": "u",
+    "ф": "f",
+    "х": "kh",
+    "ц": "ts",
+    "ч": "ch",
+    "ш": "sh",
+    "щ": "shch",
+    "ъ": "",
+    "ы": "y",
+    "ь": "",
+    "э": "e",
+    "ю": "yu",
+    "я": "ya",
+}
+
+_ARABIC_MAP = {
+    "ا": "a",
+    "أ": "a",
+    "إ": "i",
+    "آ": "a",
+    "ب": "b",
+    "ت": "t",
+    "ث": "th",
+    "ج": "j",
+    "ح": "h",
+    "خ": "kh",
+    "د": "d",
+    "ذ": "dh",
+    "ر": "r",
+    "ز": "z",
+    "س": "s",
+    "ش": "sh",
+    "ص": "s",
+    "ض": "d",
+    "ط": "t",
+    "ظ": "z",
+    "ع": "a",
+    "غ": "gh",
+    "ف": "f",
+    "ق": "q",
+    "ك": "k",
+    "ل": "l",
+    "م": "m",
+    "ن": "n",
+    "ه": "h",
+    "و": "w",
+    "ي": "y",
+    "ى": "a",
+    "ة": "h",
+    "ء": "",
+}
+
+_DEVANAGARI_MAP = {
+    "अ": "a",
+    "आ": "aa",
+    "इ": "i",
+    "ई": "ii",
+    "उ": "u",
+    "ऊ": "uu",
+    "ऋ": "ri",
+    "ए": "e",
+    "ऐ": "ai",
+    "ओ": "o",
+    "औ": "au",
+    "क": "k",
+    "ख": "kh",
+    "ग": "g",
+    "घ": "gh",
+    "ङ": "ng",
+    "च": "ch",
+    "छ": "chh",
+    "ज": "j",
+    "झ": "jh",
+    "ञ": "ny",
+    "ट": "t",
+    "ठ": "th",
+    "ड": "d",
+    "ढ": "dh",
+    "ण": "n",
+    "त": "t",
+    "थ": "th",
+    "द": "d",
+    "ध": "dh",
+    "न": "n",
+    "प": "p",
+    "फ": "ph",
+    "ब": "b",
+    "भ": "bh",
+    "म": "m",
+    "य": "y",
+    "र": "r",
+    "ल": "l",
+    "व": "v",
+    "श": "sh",
+    "ष": "sh",
+    "स": "s",
+    "ह": "h",
+}
+
+_HEBREW_MAP = {
+    "א": "a",
+    "ב": "b",
+    "ג": "g",
+    "ד": "d",
+    "ה": "h",
+    "ו": "v",
+    "ז": "z",
+    "ח": "h",
+    "ט": "t",
+    "י": "y",
+    "כ": "k",
+    "ל": "l",
+    "מ": "m",
+    "נ": "n",
+    "ס": "s",
+    "ע": "a",
+    "פ": "p",
+    "צ": "ts",
+    "ק": "k",
+    "ר": "r",
+    "ש": "sh",
+    "ת": "t",
+}
+
+_HANGUL_NORMALIZER = lambda value: unicodedata.normalize("NFKD", value)
+
+
+def _hangul_romanize(value: str) -> str:
+    decomposed = unicodedata.normalize("NFKD", value)
+    ascii_text = _ascii_fallback(decomposed)
+    return ascii_text or value
+
+
+def _kana_romanize(value: str) -> str:
+    # Katakana/Hiragana to ASCII via compatibility decomposition.
+    decomposed = unicodedata.normalize("NFKD", value)
+    ascii_text = _ascii_fallback(decomposed)
+    return ascii_text or value
+
+
+_DEFAULT_PROFILES: Tuple[LanguageProfile, ...] = (
+    LanguageProfile(
+        code="en",
+        name="English",
+        description="Latin script with accent stripping",
+        script_ranges=_LATIN_RANGES,
+        romanizer=_strip_accents,
+    ),
+    LanguageProfile(
+        code="es",
+        name="Spanish",
+        description="Latin script with accent stripping",
+        script_ranges=_LATIN_RANGES,
+        romanizer=_strip_accents,
+    ),
+    LanguageProfile(
+        code="fr",
+        name="French",
+        description="Latin script with accent stripping",
+        script_ranges=_LATIN_RANGES,
+        romanizer=_strip_accents,
+    ),
+    LanguageProfile(
+        code="de",
+        name="German",
+        description="Latin script with umlaut handling",
+        script_ranges=_LATIN_RANGES,
+        romanizer=lambda value: _strip_accents(value.replace("ß", "ss")),
+    ),
+    LanguageProfile(
+        code="pt",
+        name="Portuguese",
+        description="Latin script with accent stripping",
+        script_ranges=_LATIN_RANGES,
+        romanizer=_strip_accents,
+    ),
+    LanguageProfile(
+        code="el",
+        name="Greek",
+        description="Greek to Latin transliteration",
+        script_ranges=_GREEK_RANGES,
+        romanizer=lambda value: _transliterate_with_mapping(value, _GREEK_MAP),
+    ),
+    LanguageProfile(
+        code="ru",
+        name="Russian",
+        description="Cyrillic to Latin transliteration",
+        script_ranges=_CYRILLIC_RANGES,
+        romanizer=lambda value: _transliterate_with_mapping(value, _CYRILLIC_MAP),
+    ),
+    LanguageProfile(
+        code="uk",
+        name="Ukrainian",
+        description="Cyrillic to Latin transliteration",
+        script_ranges=_CYRILLIC_RANGES,
+        romanizer=lambda value: _transliterate_with_mapping(value, _CYRILLIC_MAP),
+    ),
+    LanguageProfile(
+        code="ar",
+        name="Arabic",
+        description="Arabic to Latin transliteration",
+        script_ranges=_ARABIC_RANGES,
+        romanizer=lambda value: _transliterate_with_mapping(value, _ARABIC_MAP),
+    ),
+    LanguageProfile(
+        code="he",
+        name="Hebrew",
+        description="Hebrew to Latin transliteration",
+        script_ranges=_HEBREW_RANGES,
+        romanizer=lambda value: _transliterate_with_mapping(value, _HEBREW_MAP),
+    ),
+    LanguageProfile(
+        code="hi",
+        name="Hindi",
+        description="Devanagari to Latin transliteration",
+        script_ranges=_DEVANAGARI_RANGES,
+        romanizer=lambda value: _transliterate_with_mapping(value, _DEVANAGARI_MAP),
+    ),
+    LanguageProfile(
+        code="ko",
+        name="Korean",
+        description="Hangul compatibility decomposition",
+        script_ranges=_HANGUL_RANGES,
+        romanizer=_hangul_romanize,
+        normalizer=_HANGUL_NORMALIZER,
+    ),
+    LanguageProfile(
+        code="ja",
+        name="Japanese",
+        description="Kana compatibility decomposition",
+        script_ranges=_HIRAGANA_RANGES + _KATAKANA_RANGES,
+        romanizer=_kana_romanize,
+        normalizer=_normalize_lower,
+    ),
+)
+
+
+def default_language_registry() -> LanguageProfileRegistry:
+    return LanguageProfileRegistry(_DEFAULT_PROFILES)

--- a/phonetic_api.py
+++ b/phonetic_api.py
@@ -96,6 +96,13 @@ class PhoneticAPI:
         include_report = options.get("include_report", True)
         include_comparability = options.get("include_comparability", bool(reference_text))
         language_code = data.get("language_code") or options.get("language_code")
+        exclude_languages = options.get("exclude_languages") or data.get("exclude_languages")
+        if exclude_languages is not None and not isinstance(exclude_languages, list):
+            return self._respond_json(
+                start_response,
+                {"error": "'exclude_languages' must be a list of language codes"},
+                status="400 Bad Request",
+            )
 
         analysis = self._model.analyze(
             text,
@@ -105,6 +112,7 @@ class PhoneticAPI:
             window_size=window_size,
             compare=bool(reference_text and include_comparability),
             language_code=language_code,
+            exclude_languages=exclude_languages,
         )
 
         response = {
@@ -120,6 +128,7 @@ class PhoneticAPI:
                 include_report=include_report,
                 include_comparability=include_comparability,
                 language_code=language_code,
+                exclude_languages=exclude_languages,
             )
             response["bundle"] = bundle.as_dict()
 

--- a/phonetic_api.py
+++ b/phonetic_api.py
@@ -1,0 +1,160 @@
+"""WSGI wrapper exposing the phonetic trailing song model over HTTP."""
+
+from __future__ import annotations
+
+import json
+from typing import Callable, Dict, Iterable
+
+from phonetic_trailing_song_model import (
+    PhoneticTrailingSongModel,
+    prepare_data_generation,
+)
+
+
+class PhoneticAPI:
+    """Minimal WSGI application for phonetic analysis."""
+
+    def __init__(self) -> None:
+        self._model = PhoneticTrailingSongModel()
+
+    # The WSGI application interface -------------------------------------------------
+    def __call__(self, environ: Dict[str, object], start_response: Callable) -> Iterable[bytes]:
+        method = environ.get("REQUEST_METHOD", "GET")
+        path = environ.get("PATH_INFO", "/") or "/"
+
+        if method == "GET" and path == "/health":
+            return self._respond_json(start_response, {"status": "ok"})
+        if method == "GET" and path == "/":
+            metadata = {
+                "name": "phonetic-trailing-song-api",
+                "endpoints": [
+                    {"path": "/", "method": "GET", "description": "API metadata"},
+                    {"path": "/health", "method": "GET", "description": "Liveness check"},
+                    {
+                        "path": "/analyze",
+                        "method": "POST",
+                        "description": "Run phonetic analysis and optional bundle export",
+                    },
+                ],
+                "capabilities": [
+                    "structured_analysis",
+                    "silent_language_titles",
+                    "read_aloud_codex",
+                    "knowledge_base",
+                    "data_bundle_export",
+                ],
+                "languages": [
+                    {
+                        "code": profile.code,
+                        "name": profile.name,
+                        "description": profile.description,
+                    }
+                    for profile in self._model.language_registry.list_profiles()
+                ],
+            }
+            return self._respond_json(start_response, metadata)
+        if method == "POST" and path == "/analyze":
+            return self._handle_analyze(environ, start_response)
+
+        return self._respond_json(start_response, {"error": "Not found"}, status="404 Not Found")
+
+    # ------------------------------------------------------------------
+    def _handle_analyze(self, environ: Dict[str, object], start_response: Callable) -> Iterable[bytes]:
+        try:
+            length = int(environ.get("CONTENT_LENGTH") or 0)
+        except (ValueError, TypeError):
+            length = 0
+        wsgi_input = environ.get("wsgi.input")
+        if hasattr(wsgi_input, "read"):
+            body_bytes = wsgi_input.read(length)
+        else:
+            body_bytes = b""
+        payload = body_bytes.decode("utf-8") if body_bytes else "{}"
+        try:
+            data = json.loads(payload or "{}")
+        except json.JSONDecodeError:
+            return self._respond_json(
+                start_response,
+                {"error": "Invalid JSON payload"},
+                status="400 Bad Request",
+            )
+
+        text = data.get("text")
+        reference_text = data.get("reference_text")
+        options = data.get("options", {}) if isinstance(data.get("options"), dict) else {}
+        title = data.get("title") or options.get("title")
+
+        if not text:
+            return self._respond_json(
+                start_response,
+                {"error": "Missing 'text' field"},
+                status="400 Bad Request",
+            )
+
+        include_bundle = bool(options.get("include_bundle"))
+        window_size = int(options.get("window_size") or 4)
+        include_report = options.get("include_report", True)
+        include_comparability = options.get("include_comparability", bool(reference_text))
+        language_code = data.get("language_code") or options.get("language_code")
+
+        analysis = self._model.analyze(
+            text,
+            title=title,
+            reference_text=reference_text,
+            seed_from=data.get("seed_from"),
+            window_size=window_size,
+            compare=bool(reference_text and include_comparability),
+            language_code=language_code,
+        )
+
+        response = {
+            "analysis": analysis.as_dict(),
+        }
+
+        if include_bundle:
+            bundle = prepare_data_generation(
+                text,
+                title=title,
+                reference_text=reference_text,
+                window_size=window_size,
+                include_report=include_report,
+                include_comparability=include_comparability,
+                language_code=language_code,
+            )
+            response["bundle"] = bundle.as_dict()
+
+        return self._respond_json(start_response, response)
+
+    # ------------------------------------------------------------------
+    def _respond_json(
+        self,
+        start_response: Callable,
+        payload: Dict[str, object],
+        *,
+        status: str = "200 OK",
+    ) -> Iterable[bytes]:
+        body = json.dumps(payload, ensure_ascii=False).encode("utf-8")
+        start_response(status, [("Content-Type", "application/json"), ("Content-Length", str(len(body)))])
+        return [body]
+
+
+def make_app() -> PhoneticAPI:
+    return PhoneticAPI()
+
+
+if __name__ == "__main__":  # pragma: no cover
+    from wsgiref.simple_server import make_server
+    import argparse
+
+    parser = argparse.ArgumentParser(description="Run the phonetic API")
+    parser.add_argument("--host", default="0.0.0.0")
+    parser.add_argument("--port", type=int, default=8000)
+    args = parser.parse_args()
+
+    app = PhoneticAPI()
+    with make_server(args.host, args.port, app) as httpd:
+        print(f"Serving on http://{args.host}:{args.port}")
+        try:
+            httpd.serve_forever()
+        except KeyboardInterrupt:
+            print("Stopping server…")

--- a/phonetic_trailing_song_model.py
+++ b/phonetic_trailing_song_model.py
@@ -1,0 +1,1501 @@
+"""Phonetic trailing song analysis toolkit.
+
+This module exposes a high level :class:`PhoneticTrailingSongModel` that can be
+used to derive deterministic numeric signatures, phonetic summaries, and
+navigational metadata for arbitrary text.  The implementation is intentionally
+self-contained so it can operate in restricted execution environments where
+third‑party phonetic libraries are not available.
+
+The design mirrors the feature set that evolved throughout the previous chat
+iteration:
+
+* title sound fragments and base-36 numeric seeds
+* numeric equivalence groupings and repetition clusters
+* binary bookmark/codex markers with absence detection
+* cursor friendly table-of-contents and title language records
+* universal similarity groupings across scripts
+* slider-ready per-token seed metrics and language layering metadata
+* comparability utilities for sliding window inspection
+* data-generation bundle helpers for ML workflows
+
+The functions in this module favour deterministic hashing so that multiple runs
+with the same inputs always yield the same outputs.
+"""
+
+from __future__ import annotations
+
+import argparse
+import dataclasses
+import hashlib
+import json
+import statistics
+import sys
+from dataclasses import dataclass
+from pathlib import Path
+from typing import Dict, Iterator, List, Optional, Sequence, Tuple
+import unicodedata
+import re
+
+from language_profiles import (
+    LanguageProfile,
+    LanguageProfileRegistry,
+    default_language_registry,
+)
+
+__all__ = [
+    "PhoneticTrailingSongModel",
+    "AnalysisResult",
+    "LanguageUsage",
+    "SilentLanguageTitle",
+    "ReadAloudCodexEntry",
+    "SyllableBeat",
+    "KnowledgeBase",
+    "prepare_data_generation",
+    "analyze_text",
+]
+
+_WORD_RE = re.compile(r"\b\w+\b", re.UNICODE)
+_BASE36_ALPHABET = "0123456789abcdefghijklmnopqrstuvwxyz"
+_SYLLABLE_VOWELS = set("aeiouy")
+
+
+def _strip_accents(value: str) -> str:
+    normalized = unicodedata.normalize("NFKD", value)
+    return "".join(ch for ch in normalized if unicodedata.category(ch) != "Mn")
+
+
+def _ascii_fallback(value: str) -> str:
+    ascii_bytes = _strip_accents(value).encode("ascii", "ignore")
+    fallback = ascii_bytes.decode("ascii", "ignore")
+    return fallback or value.lower()
+
+
+def _base36(value: int) -> str:
+    if value == 0:
+        return "0"
+    digits: List[str] = []
+    abs_value = abs(value)
+    while abs_value:
+        abs_value, rem = divmod(abs_value, 36)
+        digits.append(_BASE36_ALPHABET[rem])
+    if value < 0:
+        digits.append("-")
+    return "".join(reversed(digits))
+
+
+def _hash_int(seed: str, modulo: int = 36 ** 6) -> int:
+    digest = hashlib.sha1(seed.encode("utf-8")).digest()
+    value = int.from_bytes(digest[:8], "big", signed=False)
+    return value % modulo
+
+
+def _lengthen_base36(value: int) -> str:
+    base = _base36(value)
+    doubled = ''.join(ch * 2 for ch in base)
+    return doubled or "00"
+
+
+def _cubic_value(value: int) -> int:
+    return value ** 3
+
+
+def _syllabify_candidate(raw: str) -> List[str]:
+    cleaned = re.sub(r"[^a-z0-9]+", "", raw.lower())
+    if not cleaned:
+        return []
+    segments: List[str] = []
+    start = 0
+    for idx in range(1, len(cleaned)):
+        prev = cleaned[idx - 1]
+        curr = cleaned[idx]
+        prev_is_vowel = prev in _SYLLABLE_VOWELS
+        curr_is_vowel = curr in _SYLLABLE_VOWELS
+        next_is_vowel = cleaned[idx + 1] in _SYLLABLE_VOWELS if idx + 1 < len(cleaned) else False
+        should_split = False
+        if not prev_is_vowel and curr_is_vowel:
+            should_split = True
+        elif prev_is_vowel and curr_is_vowel and not next_is_vowel:
+            should_split = True
+        elif prev_is_vowel and not curr_is_vowel and next_is_vowel:
+            should_split = True
+        if should_split and idx > start:
+            segments.append(cleaned[start:idx])
+            start = idx
+    tail = cleaned[start:]
+    if tail:
+        segments.append(tail)
+    return segments
+
+
+def _resolve_syllables(*candidates: str) -> List[str]:
+    for candidate in candidates:
+        if not candidate:
+            continue
+        segments = _syllabify_candidate(candidate)
+        if segments:
+            return segments
+    fallback = next((candidate for candidate in candidates if candidate), "")
+    return [fallback] if fallback else []
+
+
+def _slider_bar(value: int, maximum: int) -> str:
+    if maximum <= 0:
+        return "|"
+    filled = max(1, round((value / maximum) * 20))
+    return "|" + ("#" * min(filled, 20)).ljust(20, "-") + "|"
+
+
+def _chunk_sequence(seq: Sequence, size: int) -> Iterator[Sequence]:
+    for idx in range(0, len(seq), size):
+        yield seq[idx : idx + size]
+
+
+@dataclass
+class LanguageLayer:
+    kind: str
+    value: str
+
+
+@dataclass
+class LanguageLayerGrouping:
+    token_index: int
+    layers: List[LanguageLayer]
+
+
+@dataclass
+class PhoneticToken:
+    index: int
+    text: str
+    normalized: str
+    phonetic: str
+    ascii_value: str
+    base36_value: int
+    lengthened_value: str
+    cubic_value: int
+    seed: int
+    language_code: str
+    language_name: str
+    language_layers: LanguageLayerGrouping
+    syllables: List[str]
+
+    def as_dict(self) -> Dict[str, object]:
+        return {
+            "index": self.index,
+            "text": self.text,
+            "normalized": self.normalized,
+            "phonetic": self.phonetic,
+            "ascii": self.ascii_value,
+            "base36": self.base36_value,
+            "lengthened": self.lengthened_value,
+            "cubic": self.cubic_value,
+            "seed": self.seed,
+            "language_code": self.language_code,
+            "language_name": self.language_name,
+            "language_layers": [
+                dataclasses.asdict(layer) for layer in self.language_layers.layers
+            ],
+            "syllables": list(self.syllables),
+        }
+
+
+@dataclass
+class TitleSoundSummary:
+    line_number: int
+    fragment: str
+    combined_value: int
+
+    def as_dict(self) -> Dict[str, object]:
+        return dataclasses.asdict(self)
+
+
+@dataclass
+class NumericEquivalenceGroup:
+    base36_value: int
+    token_indices: List[int]
+
+    def as_dict(self) -> Dict[str, object]:
+        return dataclasses.asdict(self)
+
+
+@dataclass
+class LanguageUsage:
+    code: str
+    name: str
+    description: str
+    token_count: int
+    coverage: float
+
+    def as_dict(self) -> Dict[str, object]:
+        return dataclasses.asdict(self)
+
+
+@dataclass
+class BinaryBookmark:
+    marker_128bit: str
+    codex_key: str
+    has_absence: bool
+    absent_indices: List[int]
+
+    def as_dict(self) -> Dict[str, object]:
+        return dataclasses.asdict(self)
+
+
+@dataclass
+class TokenSeedDetail:
+    token_index: int
+    base_seed: int
+    max_seed: int
+    slider: str
+
+    def as_dict(self) -> Dict[str, object]:
+        return dataclasses.asdict(self)
+
+
+@dataclass
+class SyllableBeat:
+    token_index: int
+    syllable_index: int
+    syllable: str
+    intensity: int
+    dim_level: float
+    emphasis: str
+
+    def as_dict(self) -> Dict[str, object]:
+        return dataclasses.asdict(self)
+
+
+@dataclass
+class ReadAloudCodexEntry:
+    token_index: int
+    token_text: str
+    average_intensity: float
+    slider: str
+    beats: List[SyllableBeat]
+
+    def as_dict(self) -> Dict[str, object]:
+        return {
+            "token_index": self.token_index,
+            "token_text": self.token_text,
+            "average_intensity": self.average_intensity,
+            "slider": self.slider,
+            "beats": [beat.as_dict() for beat in self.beats],
+        }
+
+
+@dataclass
+class NumericRepetitionCluster:
+    base36_value: int
+    occurrences: List[int]
+
+    def as_dict(self) -> Dict[str, object]:
+        return dataclasses.asdict(self)
+
+
+@dataclass
+class TableOfContentsMarker:
+    anchor: str
+    title: str
+    token_range: Tuple[int, int]
+
+    def as_dict(self) -> Dict[str, object]:
+        return {
+            "anchor": self.anchor,
+            "title": self.title,
+            "token_range": list(self.token_range),
+        }
+
+
+@dataclass
+class UniversalSimilarityGroup:
+    signature: str
+    token_indices: List[int]
+
+    def as_dict(self) -> Dict[str, object]:
+        return dataclasses.asdict(self)
+
+
+@dataclass
+class TitleLanguageRecord:
+    order: int
+    anchor: str
+    narrative: str
+
+    def as_dict(self) -> Dict[str, object]:
+        return dataclasses.asdict(self)
+
+
+@dataclass
+class SilentLanguageTitle:
+    language_code: str
+    language_name: str
+    forwards_text: str
+    backwards_text: str
+    ascii_backwards: str
+    writing_seed: str
+    token_indices: List[int]
+
+    def as_dict(self) -> Dict[str, object]:
+        return dataclasses.asdict(self)
+
+
+@dataclass
+class CodeGapTitle:
+    token_index: int
+    reason: str
+
+    def as_dict(self) -> Dict[str, object]:
+        return dataclasses.asdict(self)
+
+
+@dataclass
+class NameTimeMarker:
+    order: int
+    label: str
+    summary: str
+
+    def as_dict(self) -> Dict[str, object]:
+        return dataclasses.asdict(self)
+
+
+@dataclass
+class KnowledgeEntry:
+    token_index: int
+    surface: str
+    normalized: str
+    base36: str
+    lengthened: str
+    cubic: int
+    seed: int
+    language_code: str
+    language_name: str
+    universal_signature: Optional[str]
+    numeric_group_size: int
+    repetition_count: int
+
+    def as_dict(self) -> Dict[str, object]:
+        return dataclasses.asdict(self)
+
+
+@dataclass
+class KnowledgeCluster:
+    kind: str
+    label: str
+    token_indices: List[int]
+    summary: str
+
+    def as_dict(self) -> Dict[str, object]:
+        return dataclasses.asdict(self)
+
+
+@dataclass
+class KnowledgeBase:
+    entries: List[KnowledgeEntry]
+    clusters: List[KnowledgeCluster]
+    insights: List[str]
+
+    def as_dict(self) -> Dict[str, object]:
+        return {
+            "entries": [entry.as_dict() for entry in self.entries],
+            "clusters": [cluster.as_dict() for cluster in self.clusters],
+            "insights": list(self.insights),
+        }
+
+
+@dataclass
+class ComparabilityWindow:
+    window_index: int
+    current_tokens: List[str]
+    reference_tokens: List[str]
+    numeric_overlap: float
+    similarity_overlap: float
+
+    def as_dict(self) -> Dict[str, object]:
+        return dataclasses.asdict(self)
+
+
+@dataclass
+class ComparabilityResult:
+    window_size: int
+    aggregate_numeric_similarity: float
+    aggregate_similarity_overlap: float
+    windows: List[ComparabilityWindow]
+
+    def as_dict(self) -> Dict[str, object]:
+        return {
+            "window_size": self.window_size,
+            "aggregate_numeric_similarity": self.aggregate_numeric_similarity,
+            "aggregate_similarity_overlap": self.aggregate_similarity_overlap,
+            "windows": [w.as_dict() for w in self.windows],
+        }
+
+
+@dataclass
+class DataGenerationExample:
+    prompt: str
+    completion: str
+
+    def as_dict(self) -> Dict[str, object]:
+        return dataclasses.asdict(self)
+
+
+@dataclass
+class DataGenerationBundle:
+    title: Optional[str]
+    analysis: Dict[str, object]
+    report: Optional[str]
+    comparability: Optional[Dict[str, object]]
+    examples: List[DataGenerationExample]
+
+    def as_dict(self) -> Dict[str, object]:
+        return {
+            "title": self.title,
+            "analysis": self.analysis,
+            "report": self.report,
+            "comparability": self.comparability,
+            "examples": [ex.as_dict() for ex in self.examples],
+        }
+
+
+@dataclass
+class AnalysisResult:
+    title: Optional[str]
+    tokens: List[PhoneticToken]
+    language_usage: List[LanguageUsage]
+    title_summaries: List[TitleSoundSummary]
+    numeric_equivalences: List[NumericEquivalenceGroup]
+    binary_bookmark: BinaryBookmark
+    token_seeds: List[TokenSeedDetail]
+    read_aloud_codex: List[ReadAloudCodexEntry]
+    repetition_clusters: List[NumericRepetitionCluster]
+    table_of_contents: List[TableOfContentsMarker]
+    universal_similarity: List[UniversalSimilarityGroup]
+    title_language_records: List[TitleLanguageRecord]
+    silent_language_titles: List[SilentLanguageTitle]
+    code_gap_titles: List[CodeGapTitle]
+    name_time_markers: List[NameTimeMarker]
+    knowledge_base: KnowledgeBase
+    analysis_notes: Dict[str, object]
+
+    def as_dict(self) -> Dict[str, object]:
+        return {
+            "title": self.title,
+            "tokens": [token.as_dict() for token in self.tokens],
+            "language_usage": [usage.as_dict() for usage in self.language_usage],
+            "title_summaries": [ts.as_dict() for ts in self.title_summaries],
+            "numeric_equivalences": [g.as_dict() for g in self.numeric_equivalences],
+            "binary_bookmark": self.binary_bookmark.as_dict(),
+            "token_seeds": [seed.as_dict() for seed in self.token_seeds],
+            "read_aloud_codex": [entry.as_dict() for entry in self.read_aloud_codex],
+            "repetition_clusters": [rc.as_dict() for rc in self.repetition_clusters],
+            "table_of_contents": [toc.as_dict() for toc in self.table_of_contents],
+            "universal_similarity": [g.as_dict() for g in self.universal_similarity],
+            "title_language_records": [r.as_dict() for r in self.title_language_records],
+            "silent_language_titles": [s.as_dict() for s in self.silent_language_titles],
+            "code_gap_titles": [c.as_dict() for c in self.code_gap_titles],
+            "name_time_markers": [m.as_dict() for m in self.name_time_markers],
+            "knowledge_base": self.knowledge_base.as_dict(),
+            "analysis_notes": self.analysis_notes,
+        }
+
+
+class PhoneticTrailingSongModel:
+    """Perform phonetic and numeric trailing song analysis."""
+
+    def __init__(
+        self,
+        base_seed: int = 0xC0FFEE,
+        *,
+        language_registry: Optional[LanguageProfileRegistry] = None,
+        default_language_code: str = "en",
+    ):
+        self.base_seed = base_seed
+        self.language_registry = language_registry or default_language_registry()
+        self.default_language_code = default_language_code
+
+    # ------------------------------------------------------------------
+    # Public helpers
+    def analyze(
+        self,
+        text: str,
+        *,
+        title: Optional[str] = None,
+        reference_text: Optional[str] = None,
+        seed_from: Optional[str] = None,
+        window_size: int = 4,
+        compare: bool = False,
+        language_code: Optional[str] = None,
+    ) -> AnalysisResult:
+        base_profile, detection_notes = self.language_registry.detect(
+            text,
+            preferred=language_code,
+            fallback=self.default_language_code,
+        )
+        allow_mixed = language_code is None
+        detection_notes["allow_mixed"] = allow_mixed
+
+        tokens, usage_counts = self._tokenize(
+            text,
+            base_profile=base_profile,
+            allow_mixed=allow_mixed,
+        )
+        language_usage = self._summarize_language_usage(usage_counts)
+        title_summaries = self._build_title_sound_summaries(text, tokens)
+        numeric_groups = self._group_numeric_equivalents(tokens)
+        binary_bookmark = self._build_binary_bookmark(tokens, seed_from or title)
+        token_seeds = self._build_token_seeds(tokens)
+        read_aloud_codex = self._build_read_aloud_codex(tokens, seed_from or title)
+        repetitions = self._build_repetition_clusters(tokens)
+        universal = self._build_universal_similarity(tokens)
+        silent_titles = self._build_silent_language_titles(
+            tokens,
+            language_usage,
+            title=title,
+        )
+        toc = self._build_table_of_contents(
+            tokens,
+            title_summaries,
+            universal,
+            silent_titles,
+        )
+        title_language = self._build_title_language_records(toc)
+        code_gaps = self._build_code_gap_titles(tokens, numeric_groups, binary_bookmark)
+        name_markers = self._build_name_time_markers(title_language)
+        knowledge_base = self._build_knowledge_base(
+            tokens,
+            numeric_groups,
+            universal,
+            repetitions,
+        )
+
+        notes: Dict[str, object] = {
+            "token_count": len(tokens),
+            "seed_source": seed_from or title,
+            "base_seed": self.base_seed,
+            "language_detection": detection_notes,
+        }
+
+        if compare and reference_text:
+            comparability = self.compare_texts(text, reference_text, window_size=window_size)
+            notes["comparability"] = comparability.as_dict()
+        notes["language_usage"] = [usage.as_dict() for usage in language_usage]
+        notes["silent_titles"] = [silent.as_dict() for silent in silent_titles]
+        notes["read_aloud_codex"] = {
+            "tokens": len(read_aloud_codex),
+            "syllables": sum(len(entry.beats) for entry in read_aloud_codex),
+            "max_intensity": max(
+                (beat.intensity for entry in read_aloud_codex for beat in entry.beats),
+                default=0,
+            ),
+        }
+        notes["knowledge"] = {
+            "entries": len(knowledge_base.entries),
+            "clusters": len(knowledge_base.clusters),
+        }
+
+        return AnalysisResult(
+            title=title,
+            tokens=tokens,
+            language_usage=language_usage,
+            title_summaries=title_summaries,
+            numeric_equivalences=numeric_groups,
+            binary_bookmark=binary_bookmark,
+            token_seeds=token_seeds,
+            read_aloud_codex=read_aloud_codex,
+            repetition_clusters=repetitions,
+            table_of_contents=toc,
+            universal_similarity=universal,
+            title_language_records=title_language,
+            silent_language_titles=silent_titles,
+            code_gap_titles=code_gaps,
+            name_time_markers=name_markers,
+            knowledge_base=knowledge_base,
+            analysis_notes=notes,
+        )
+
+    def compare_texts(
+        self,
+        current_text: str,
+        reference_text: str,
+        *,
+        window_size: int = 4,
+    ) -> ComparabilityResult:
+        current_profile, _ = self.language_registry.detect(
+            current_text,
+            fallback=self.default_language_code,
+        )
+        reference_profile, _ = self.language_registry.detect(
+            reference_text,
+            fallback=self.default_language_code,
+        )
+        current_tokens, _ = self._tokenize(
+            current_text,
+            base_profile=current_profile,
+            allow_mixed=True,
+        )
+        reference_tokens, _ = self._tokenize(
+            reference_text,
+            base_profile=reference_profile,
+            allow_mixed=True,
+        )
+
+        current_base36 = [token.base36_value for token in current_tokens]
+        reference_base36 = [token.base36_value for token in reference_tokens]
+        current_signatures = [token.ascii_value for token in current_tokens]
+        reference_signatures = [token.ascii_value for token in reference_tokens]
+
+        windows: List[ComparabilityWindow] = []
+        numeric_overlaps: List[float] = []
+        similarity_overlaps: List[float] = []
+
+        if window_size <= 0:
+            window_size = 1
+
+        for idx, chunk in enumerate(_chunk_sequence(current_tokens, window_size)):
+            current_slice = current_base36[idx * window_size : idx * window_size + len(chunk)]
+            ref_slice = reference_base36[idx * window_size : idx * window_size + len(chunk)]
+            cur_sig = current_signatures[idx * window_size : idx * window_size + len(chunk)]
+            ref_sig = reference_signatures[idx * window_size : idx * window_size + len(chunk)]
+
+            if not chunk:
+                continue
+
+            numeric_overlap = _sequence_overlap(current_slice, ref_slice)
+            similarity_overlap = _sequence_overlap(cur_sig, ref_sig)
+
+            windows.append(
+                ComparabilityWindow(
+                    window_index=idx,
+                    current_tokens=[t.text for t in chunk],
+                    reference_tokens=ref_tokens_slice(reference_tokens, idx, window_size),
+                    numeric_overlap=numeric_overlap,
+                    similarity_overlap=similarity_overlap,
+                )
+            )
+            numeric_overlaps.append(numeric_overlap)
+            similarity_overlaps.append(similarity_overlap)
+
+        aggregate_numeric = statistics.fmean(numeric_overlaps) if numeric_overlaps else 0.0
+        aggregate_similarity = statistics.fmean(similarity_overlaps) if similarity_overlaps else 0.0
+
+        return ComparabilityResult(
+            window_size=window_size,
+            aggregate_numeric_similarity=aggregate_numeric,
+            aggregate_similarity_overlap=aggregate_similarity,
+            windows=windows,
+        )
+
+    # ------------------------------------------------------------------
+    # Internal builders
+    def _tokenize(
+        self,
+        text: str,
+        *,
+        base_profile: LanguageProfile,
+        allow_mixed: bool,
+    ) -> Tuple[List[PhoneticToken], Dict[str, int]]:
+        tokens: List[PhoneticToken] = []
+        usage: Dict[str, int] = {}
+        for index, match in enumerate(_WORD_RE.finditer(text)):
+            raw = match.group(0)
+            if allow_mixed:
+                profile, _ = self.language_registry.detect(
+                    raw,
+                    preferred=None,
+                    fallback=base_profile.code,
+                )
+            else:
+                profile = base_profile
+
+            romanized = profile.romanize(raw)
+            ascii_candidate = _ascii_fallback(romanized)
+            ascii_value = ascii_candidate or _ascii_fallback(raw) or romanized.lower()
+            normalized_source = romanized if romanized else raw
+            normalized = profile.normalize(normalized_source)
+            phonetic = normalized.lower()
+            base36_value = _hash_int(phonetic)
+            lengthened = _lengthen_base36(base36_value)
+            cubic = _cubic_value(base36_value)
+            seed = _hash_int(f"{self.base_seed}:{phonetic}:{index}", modulo=2 ** 31)
+            syllables = _resolve_syllables(ascii_value, romanized, normalized, raw)
+            layers = LanguageLayerGrouping(
+                token_index=index,
+                layers=[
+                    LanguageLayer("original", raw),
+                    LanguageLayer("normalized", normalized),
+                    LanguageLayer("romanized", romanized),
+                    LanguageLayer("ascii", ascii_value),
+                    LanguageLayer("language", profile.code),
+                    LanguageLayer("language_name", profile.name),
+                ],
+            )
+            tokens.append(
+                PhoneticToken(
+                    index=index,
+                    text=raw,
+                    normalized=normalized,
+                    phonetic=phonetic,
+                    ascii_value=ascii_value,
+                    base36_value=base36_value,
+                    lengthened_value=lengthened,
+                    cubic_value=cubic,
+                    seed=seed,
+                    language_code=profile.code,
+                    language_name=profile.name,
+                    language_layers=layers,
+                    syllables=syllables,
+                )
+            )
+            usage[profile.code] = usage.get(profile.code, 0) + 1
+        return tokens, usage
+
+    def _build_title_sound_summaries(
+        self, text: str, tokens: Sequence[PhoneticToken]
+    ) -> List[TitleSoundSummary]:
+        summaries: List[TitleSoundSummary] = []
+        lines = text.splitlines()
+        offset = 0
+        for idx, line in enumerate(lines, start=1):
+            line_tokens = [t for t in tokens if offset <= t.index < offset + len(_WORD_RE.findall(line))]
+            fragment = " ".join(t.text for t in line_tokens[-3:]) if line_tokens else ""
+            combined = sum(t.base36_value for t in line_tokens)
+            summaries.append(TitleSoundSummary(line_number=idx, fragment=fragment, combined_value=combined))
+            offset += len(_WORD_RE.findall(line))
+        return summaries
+
+    def _group_numeric_equivalents(self, tokens: Sequence[PhoneticToken]) -> List[NumericEquivalenceGroup]:
+        groups: Dict[int, List[int]] = {}
+        for token in tokens:
+            groups.setdefault(token.base36_value, []).append(token.index)
+        return [
+            NumericEquivalenceGroup(base36_value=value, token_indices=indices)
+            for value, indices in sorted(groups.items())
+            if len(indices) > 1 or value == 0
+        ]
+
+    def _summarize_language_usage(self, usage_counts: Dict[str, int]) -> List[LanguageUsage]:
+        if not usage_counts:
+            return []
+        total = sum(usage_counts.values())
+        summaries: List[LanguageUsage] = []
+        for code, count in sorted(usage_counts.items(), key=lambda item: (-item[1], item[0])):
+            profile = self.language_registry.get(code)
+            name = profile.name if profile else code
+            description = profile.description if profile else ""
+            coverage = count / total if total else 0.0
+            summaries.append(
+                LanguageUsage(
+                    code=code,
+                    name=name,
+                    description=description,
+                    token_count=count,
+                    coverage=round(coverage, 6),
+                )
+            )
+        return summaries
+
+    def _build_binary_bookmark(
+        self, tokens: Sequence[PhoneticToken], seed_source: Optional[str]
+    ) -> BinaryBookmark:
+        combined_seed = self.base_seed
+        absent_indices: List[int] = []
+        for token in tokens:
+            combined_seed ^= token.seed
+            if token.base36_value == 0:
+                absent_indices.append(token.index)
+        if seed_source:
+            combined_seed ^= _hash_int(seed_source, modulo=2 ** 64)
+        marker = combined_seed & ((1 << 128) - 1)
+        codex = hashlib.sha256(str(combined_seed).encode("utf-8")).hexdigest()[:32]
+        has_absence = bool(absent_indices)
+        marker_hex = f"{marker:032x}"
+        return BinaryBookmark(
+            marker_128bit=marker_hex,
+            codex_key=codex,
+            has_absence=has_absence,
+            absent_indices=absent_indices,
+        )
+
+    def _build_token_seeds(self, tokens: Sequence[PhoneticToken]) -> List[TokenSeedDetail]:
+        max_seed = max((token.seed for token in tokens), default=1)
+        details: List[TokenSeedDetail] = []
+        for token in tokens:
+            slider = _slider_bar(token.seed, max_seed)
+            details.append(
+                TokenSeedDetail(
+                    token_index=token.index,
+                    base_seed=token.seed,
+                    max_seed=max_seed,
+                    slider=slider,
+                )
+            )
+        return details
+
+    def _build_read_aloud_codex(
+        self,
+        tokens: Sequence[PhoneticToken],
+        seed_source: Optional[str],
+    ) -> List[ReadAloudCodexEntry]:
+        proto_entries: List[Tuple[int, str, List[Tuple[str, int, float]]]] = []
+        global_max = 1
+        seed_basis = seed_source or ""
+        for token in tokens:
+            beat_details: List[Tuple[str, int, float]] = []
+            syllables = token.syllables or [token.phonetic]
+            for syllable_index, syllable in enumerate(syllables):
+                beat_seed_input = f"{self.base_seed}:{token.seed}:{syllable}:{syllable_index}:{seed_basis}"
+                beat_seed = _hash_int(beat_seed_input, modulo=1000)
+                intensity = 30 + (beat_seed % 71)
+                dim_level = round((100 - intensity) / 100, 3)
+                beat_details.append((syllable, intensity, dim_level))
+                global_max = max(global_max, intensity)
+            proto_entries.append((token.index, token.text, beat_details))
+
+        codex_entries: List[ReadAloudCodexEntry] = []
+        for token_index, token_text, beat_info in proto_entries:
+            if beat_info:
+                intensities = [info[1] for info in beat_info]
+                avg_intensity = sum(intensities) / len(intensities)
+                peak_intensity = max(intensities)
+            else:
+                intensities = []
+                avg_intensity = 0.0
+                peak_intensity = 0
+            slider = _slider_bar(int(round(avg_intensity)), int(global_max))
+            beats: List[SyllableBeat] = []
+            for syllable_index, (syllable, intensity, dim_level) in enumerate(beat_info):
+                emphasis = "primary" if intensity == peak_intensity else "secondary"
+                beats.append(
+                    SyllableBeat(
+                        token_index=token_index,
+                        syllable_index=syllable_index,
+                        syllable=syllable,
+                        intensity=intensity,
+                        dim_level=dim_level,
+                        emphasis=emphasis,
+                    )
+                )
+            codex_entries.append(
+                ReadAloudCodexEntry(
+                    token_index=token_index,
+                    token_text=token_text,
+                    average_intensity=round(avg_intensity, 2),
+                    slider=slider,
+                    beats=beats,
+                )
+            )
+
+        return codex_entries
+
+    def _build_repetition_clusters(
+        self, tokens: Sequence[PhoneticToken]
+    ) -> List[NumericRepetitionCluster]:
+        occurrences: Dict[int, List[int]] = {}
+        for token in tokens:
+            occurrences.setdefault(token.base36_value, []).append(token.index)
+        clusters = [
+            NumericRepetitionCluster(base36_value=value, occurrences=indices)
+            for value, indices in sorted(occurrences.items())
+            if len(indices) > 1
+        ]
+        return clusters
+
+    def _build_universal_similarity(
+        self, tokens: Sequence[PhoneticToken]
+    ) -> List[UniversalSimilarityGroup]:
+        groups: Dict[str, List[int]] = {}
+        for token in tokens:
+            groups.setdefault(token.ascii_value, []).append(token.index)
+        return [
+            UniversalSimilarityGroup(signature=sig, token_indices=indices)
+            for sig, indices in sorted(groups.items())
+            if len(indices) > 1
+        ]
+
+    def _build_table_of_contents(
+        self,
+        tokens: Sequence[PhoneticToken],
+        summaries: Sequence[TitleSoundSummary],
+        universal: Sequence[UniversalSimilarityGroup],
+        silent_titles: Sequence[SilentLanguageTitle],
+    ) -> List[TableOfContentsMarker]:
+        markers: List[TableOfContentsMarker] = []
+        sections = [
+            (f"line-{summary.line_number}", f"Line {summary.line_number}: {summary.fragment or '∅'}")
+            for summary in summaries
+        ]
+        sections += [
+            (f"similarity-{group.signature}", f"Similarity: {group.signature}")
+            for group in universal[:10]
+        ]
+        sections += [
+            (f"silent-{silent.language_code}", f"Silent {silent.language_name}")
+            for silent in silent_titles
+        ]
+        for idx, (anchor, title) in enumerate(sections):
+            start = idx * max(1, len(tokens) // max(1, len(sections)))
+            end = min(len(tokens), start + max(1, len(tokens) // max(1, len(sections))))
+            markers.append(
+                TableOfContentsMarker(
+                    anchor=anchor,
+                    title=title,
+                    token_range=(start, end),
+                )
+            )
+        return markers
+
+    def _build_title_language_records(
+        self, toc: Sequence[TableOfContentsMarker]
+    ) -> List[TitleLanguageRecord]:
+        records: List[TitleLanguageRecord] = []
+        for order, marker in enumerate(sorted(toc, key=lambda m: m.anchor, reverse=True)):
+            narrative = f"{marker.title} (tokens {marker.token_range[0]}-{marker.token_range[1]})"
+            records.append(
+                TitleLanguageRecord(order=order + 1, anchor=marker.anchor, narrative=narrative)
+            )
+        return records
+
+    def _build_silent_language_titles(
+        self,
+        tokens: Sequence[PhoneticToken],
+        usage: Sequence[LanguageUsage],
+        *,
+        title: Optional[str],
+    ) -> List[SilentLanguageTitle]:
+        usage_lookup = {item.code: item for item in usage}
+        tokens_by_language: Dict[str, List[PhoneticToken]] = {}
+        for token in tokens:
+            tokens_by_language.setdefault(token.language_code, []).append(token)
+
+        silent_titles: List[SilentLanguageTitle] = []
+        for code, lang_tokens in sorted(tokens_by_language.items()):
+            usage_item = usage_lookup.get(code)
+            language_name = usage_item.name if usage_item else code
+            forward_tokens = [token.normalized for token in lang_tokens if token.normalized]
+            forward_text = " ".join(forward_tokens).strip()
+            if not forward_text and title:
+                forward_text = title
+            reversed_tokens = list(reversed(lang_tokens))
+            backwards_text = " ".join(
+                token.normalized for token in reversed_tokens if token.normalized
+            ).strip()
+            if not backwards_text and forward_text:
+                backwards_text = " ".join(reversed(forward_text.split()))
+            ascii_backwards = _ascii_fallback(backwards_text) if backwards_text else ""
+            seed_input = f"{code}:{backwards_text or forward_text or title or ''}"
+            seed_value = _hash_int(seed_input, modulo=36 ** 8)
+            silent_titles.append(
+                SilentLanguageTitle(
+                    language_code=code,
+                    language_name=f"{language_name} (silent writing)",
+                    forwards_text=forward_text,
+                    backwards_text=backwards_text,
+                    ascii_backwards=ascii_backwards,
+                    writing_seed=_base36(seed_value),
+                    token_indices=[token.index for token in lang_tokens],
+                )
+            )
+
+        if not silent_titles and title:
+            backwards_title = " ".join(reversed(title.split())) or title[::-1]
+            ascii_backwards = _ascii_fallback(backwards_title) if backwards_title else ""
+            seed_value = _hash_int(f"title:{title}", modulo=36 ** 8)
+            silent_titles.append(
+                SilentLanguageTitle(
+                    language_code="title",
+                    language_name="Title (silent writing)",
+                    forwards_text=title,
+                    backwards_text=backwards_title,
+                    ascii_backwards=ascii_backwards,
+                    writing_seed=_base36(seed_value),
+                    token_indices=[],
+                )
+            )
+
+        return silent_titles
+
+    def _build_code_gap_titles(
+        self,
+        tokens: Sequence[PhoneticToken],
+        groups: Sequence[NumericEquivalenceGroup],
+        bookmark: BinaryBookmark,
+    ) -> List[CodeGapTitle]:
+        gaps: List[CodeGapTitle] = []
+        zero_tokens = [token for token in tokens if token.base36_value == 0]
+        for token in zero_tokens:
+            gaps.append(CodeGapTitle(token_index=token.index, reason="zero-value token"))
+        if bookmark.has_absence:
+            for index in bookmark.absent_indices:
+                gaps.append(CodeGapTitle(token_index=index, reason="bookmark absence coverage"))
+        covered_indices = {idx for group in groups for idx in group.token_indices}
+        for token in tokens:
+            if token.index not in covered_indices and token.base36_value != 0:
+                gaps.append(CodeGapTitle(token_index=token.index, reason="unique numeric signature"))
+        return gaps
+
+    def _build_name_time_markers(
+        self, records: Sequence[TitleLanguageRecord]
+    ) -> List[NameTimeMarker]:
+        markers: List[NameTimeMarker] = []
+        for record in records:
+            label = f"#{record.order} {record.anchor}"
+            summary = record.narrative
+            markers.append(NameTimeMarker(order=record.order, label=label, summary=summary))
+        return markers
+
+    def _build_knowledge_base(
+        self,
+        tokens: Sequence[PhoneticToken],
+        numeric_groups: Sequence[NumericEquivalenceGroup],
+        universal_groups: Sequence[UniversalSimilarityGroup],
+        repetitions: Sequence[NumericRepetitionCluster],
+    ) -> KnowledgeBase:
+        numeric_membership: Dict[int, int] = {}
+        for group in numeric_groups:
+            for idx in group.token_indices:
+                numeric_membership[idx] = len(group.token_indices)
+
+        universal_membership: Dict[int, str] = {}
+        for group in universal_groups:
+            for idx in group.token_indices:
+                universal_membership.setdefault(idx, group.signature)
+
+        repetition_membership: Dict[int, int] = {}
+        for cluster in repetitions:
+            for idx in cluster.occurrences:
+                repetition_membership[idx] = len(cluster.occurrences)
+
+        entries: List[KnowledgeEntry] = []
+        for token in tokens:
+            entries.append(
+                KnowledgeEntry(
+                    token_index=token.index,
+                    surface=token.text,
+                    normalized=token.normalized,
+                    base36=_base36(token.base36_value),
+                    lengthened=token.lengthened_value,
+                    cubic=token.cubic_value,
+                    seed=token.seed,
+                    language_code=token.language_code,
+                    language_name=token.language_name,
+                    universal_signature=universal_membership.get(token.index),
+                    numeric_group_size=numeric_membership.get(token.index, 1),
+                    repetition_count=repetition_membership.get(token.index, 1),
+                )
+            )
+
+        clusters: List[KnowledgeCluster] = []
+        for group in numeric_groups:
+            base36_value = _base36(group.base36_value)
+            clusters.append(
+                KnowledgeCluster(
+                    kind="numeric",
+                    label=base36_value,
+                    token_indices=group.token_indices,
+                    summary=f"{len(group.token_indices)} tokens share numeric signature {base36_value}",
+                )
+            )
+        for group in universal_groups:
+            clusters.append(
+                KnowledgeCluster(
+                    kind="universal",
+                    label=group.signature,
+                    token_indices=group.token_indices,
+                    summary=f"{len(group.token_indices)} tokens share universal signature '{group.signature}'",
+                )
+            )
+        for cluster in repetitions:
+            base36_value = _base36(cluster.base36_value)
+            clusters.append(
+                KnowledgeCluster(
+                    kind="repetition",
+                    label=base36_value,
+                    token_indices=cluster.occurrences,
+                    summary=f"{len(cluster.occurrences)} repeated occurrences of {base36_value}",
+                )
+            )
+
+        insights: List[str] = []
+        if tokens:
+            unique_signatures = len({token.base36_value for token in tokens})
+            insights.append(
+                f"{unique_signatures} unique base36 signatures across {len(tokens)} tokens"
+            )
+            strongest_seed = max(tokens, key=lambda token: token.seed)
+            insights.append(
+                f"Highest seed token #{strongest_seed.index} '{strongest_seed.text}' (seed {strongest_seed.seed})"
+            )
+            language_counts: Dict[str, int] = {}
+            for token in tokens:
+                language_counts[token.language_name] = language_counts.get(token.language_name, 0) + 1
+            if language_counts:
+                primary_language, count = max(language_counts.items(), key=lambda item: item[1])
+                insights.append(f"Primary language {primary_language} covers {count} tokens")
+        if numeric_groups:
+            top_numeric = max(numeric_groups, key=lambda group: len(group.token_indices))
+            insights.append(
+                f"Numeric signature {_base36(top_numeric.base36_value)} repeats {len(top_numeric.token_indices)} times"
+            )
+        if universal_groups:
+            top_universal = max(universal_groups, key=lambda group: len(group.token_indices))
+            insights.append(
+                f"Universal signature '{top_universal.signature}' shared by {len(top_universal.token_indices)} tokens"
+            )
+
+        deduped_insights = list(dict.fromkeys(insights))
+        return KnowledgeBase(entries=entries, clusters=clusters, insights=deduped_insights)
+
+    # ------------------------------------------------------------------
+    # Reporting helpers
+    def build_report(
+        self,
+        analysis: AnalysisResult,
+        *,
+        include_comparability: bool = True,
+    ) -> str:
+        lines: List[str] = []
+        if analysis.title:
+            lines.append(f"Analysis Title: {analysis.title}")
+        lines.append(f"Token count: {len(analysis.tokens)}")
+        lines.append("Silent Writing Titles:")
+        for silent in analysis.silent_language_titles:
+            backwards = silent.backwards_text or "∅"
+            lines.append(
+                f"  - {silent.language_code}: {backwards} [seed {silent.writing_seed}]"
+            )
+            if silent.forwards_text and silent.forwards_text != backwards:
+                lines.append(f"    forwards: {silent.forwards_text}")
+            if (
+                silent.ascii_backwards
+                and silent.ascii_backwards != backwards
+                and silent.ascii_backwards != silent.forwards_text
+            ):
+                lines.append(f"    ascii: {silent.ascii_backwards}")
+        if not analysis.silent_language_titles:
+            lines.append("  (none)")
+        lines.append("")
+        if analysis.language_usage:
+            lines.append("Language Usage:")
+            for usage in analysis.language_usage:
+                percentage = f"{usage.coverage * 100:.2f}%"
+                lines.append(
+                    f"  - {usage.code}: {usage.name} ({usage.token_count} tokens, {percentage})"
+                )
+            lines.append("")
+        lines.append("Table of Contents:")
+        for marker in analysis.table_of_contents:
+            lines.append(f"  - [{marker.anchor}] {marker.title}")
+        lines.append("")
+        lines.append("Title Language Records (descending):")
+        for record in analysis.title_language_records:
+            lines.append(f"  {record.order}. {record.narrative}")
+        lines.append("")
+        lines.append("Binary Bookmark:")
+        lines.append(f"  Marker: {analysis.binary_bookmark.marker_128bit}")
+        lines.append(f"  Codex:  {analysis.binary_bookmark.codex_key}")
+        if analysis.binary_bookmark.has_absence:
+            lines.append(f"  Absences at tokens: {analysis.binary_bookmark.absent_indices}")
+        lines.append("")
+        lines.append("Numeric Equivalences:")
+        for group in analysis.numeric_equivalences[:10]:
+            lines.append(f"  value={group.base36_value} indices={group.token_indices}")
+        if not analysis.numeric_equivalences:
+            lines.append("  (none)")
+        lines.append("")
+        lines.append("Repetition Clusters:")
+        for cluster in analysis.repetition_clusters[:10]:
+            lines.append(f"  value={cluster.base36_value} occurrences={cluster.occurrences}")
+        if not analysis.repetition_clusters:
+            lines.append("  (none)")
+        lines.append("")
+        lines.append("Token Seeds:")
+        for seed in analysis.token_seeds[:10]:
+            lines.append(f"  idx={seed.token_index} seed={seed.base_seed} {seed.slider}")
+        if not analysis.token_seeds:
+            lines.append("  (none)")
+        lines.append("")
+        lines.append("Read Aloud Codex (first 10 tokens):")
+        for entry in analysis.read_aloud_codex[:10]:
+            beat_summary = ", ".join(
+                f"{beat.syllable}:{beat.intensity}" for beat in entry.beats
+            ) or "∅"
+            lines.append(
+                f"  idx={entry.token_index} '{entry.token_text}' avg={entry.average_intensity} {entry.slider} -> {beat_summary}"
+            )
+        if not analysis.read_aloud_codex:
+            lines.append("  (none)")
+        lines.append("")
+        lines.append("Universal Similarity Groups:")
+        for group in analysis.universal_similarity[:10]:
+            lines.append(f"  signature={group.signature} indices={group.token_indices}")
+        if not analysis.universal_similarity:
+            lines.append("  (none)")
+        lines.append("")
+        lines.append("Code Gap Titles:")
+        for gap in analysis.code_gap_titles[:10]:
+            lines.append(f"  idx={gap.token_index} reason={gap.reason}")
+        if not analysis.code_gap_titles:
+            lines.append("  (none)")
+        lines.append("")
+        lines.append("Name Order Timeline:")
+        for marker in analysis.name_time_markers:
+            lines.append(f"  {marker.label}: {marker.summary}")
+        lines.append("")
+        lines.append("Knowledge Base Insights:")
+        for insight in analysis.knowledge_base.insights[:10]:
+            lines.append(f"  - {insight}")
+        if not analysis.knowledge_base.insights:
+            lines.append("  (none)")
+        lines.append("")
+        lines.append("Knowledge Entries (first 5):")
+        for entry in analysis.knowledge_base.entries[:5]:
+            universal = entry.universal_signature or "∅"
+            lines.append(
+                f"  #{entry.token_index} '{entry.surface}' base36={entry.base36} universal={universal} group={entry.numeric_group_size}"
+            )
+        if not analysis.knowledge_base.entries:
+            lines.append("  (none)")
+        lines.append("")
+        lines.append("Knowledge Clusters (first 5):")
+        for cluster in analysis.knowledge_base.clusters[:5]:
+            lines.append(f"  [{cluster.kind}] {cluster.summary} -> {cluster.token_indices}")
+        if not analysis.knowledge_base.clusters:
+            lines.append("  (none)")
+        if include_comparability and "comparability" in analysis.analysis_notes:
+            lines.append("")
+            lines.append("Comparability Summary:")
+            comp = analysis.analysis_notes["comparability"]
+            lines.append(
+                f"  Window Size: {comp['window_size']} | Numeric: {comp['aggregate_numeric_similarity']:.3f} | "
+                f"Similarity: {comp['aggregate_similarity_overlap']:.3f}"
+            )
+        return "\n".join(lines)
+
+    # ------------------------------------------------------------------
+    # Data generation
+    def prepare_data_generation(
+        self,
+        text: str,
+        *,
+        title: Optional[str] = None,
+        reference_text: Optional[str] = None,
+        window_size: int = 4,
+        include_report: bool = True,
+        include_comparability: bool = True,
+        language_code: Optional[str] = None,
+    ) -> DataGenerationBundle:
+        analysis = self.analyze(
+            text,
+            title=title,
+            reference_text=reference_text,
+            seed_from=title,
+            window_size=window_size,
+            compare=bool(reference_text and include_comparability),
+            language_code=language_code,
+        )
+        report = self.build_report(analysis, include_comparability=include_comparability) if include_report else None
+        comparability_dict = (
+            analysis.analysis_notes.get("comparability") if include_comparability else None
+        )
+        examples = self._build_examples(analysis, report)
+        return DataGenerationBundle(
+            title=title,
+            analysis=analysis.as_dict(),
+            report=report,
+            comparability=comparability_dict,
+            examples=examples,
+        )
+
+    def _build_examples(
+        self, analysis: AnalysisResult, report: Optional[str]
+    ) -> List[DataGenerationExample]:
+        examples: List[DataGenerationExample] = []
+        summary_prompt = "Summarise the binary bookmark significance"
+        summary_completion = json.dumps(analysis.binary_bookmark.as_dict())
+        examples.append(DataGenerationExample(prompt=summary_prompt, completion=summary_completion))
+        if analysis.knowledge_base.insights:
+            insights_prompt = "List the primary knowledge base insights"
+            insights_completion = json.dumps(
+                analysis.knowledge_base.insights[:5], ensure_ascii=False
+            )
+            examples.append(
+                DataGenerationExample(prompt=insights_prompt, completion=insights_completion)
+            )
+        if report:
+            examples.append(
+                DataGenerationExample(
+                    prompt="Provide a concise navigation summary",
+                    completion="\n".join(report.splitlines()[:10]),
+                )
+            )
+        return examples
+
+
+# ----------------------------------------------------------------------
+# Utility helpers outside the class
+
+def ref_tokens_slice(tokens: Sequence[PhoneticToken], idx: int, window_size: int) -> List[str]:
+    start = idx * window_size
+    return [token.text for token in tokens[start : start + window_size]]
+
+
+def _sequence_overlap(seq_a: Sequence[object], seq_b: Sequence[object]) -> float:
+    if not seq_a and not seq_b:
+        return 1.0
+    if not seq_a or not seq_b:
+        return 0.0
+    set_a = set(seq_a)
+    set_b = set(seq_b)
+    intersection = set_a & set_b
+    union = set_a | set_b
+    if not union:
+        return 0.0
+    return len(intersection) / len(union)
+
+
+def analyze_text(
+    text: str,
+    *,
+    title: Optional[str] = None,
+    reference_text: Optional[str] = None,
+    window_size: int = 4,
+    language_code: Optional[str] = None,
+) -> AnalysisResult:
+    model = PhoneticTrailingSongModel()
+    return model.analyze(
+        text,
+        title=title,
+        reference_text=reference_text,
+        window_size=window_size,
+        compare=bool(reference_text),
+        language_code=language_code,
+    )
+
+
+def prepare_data_generation(
+    text: str,
+    *,
+    title: Optional[str] = None,
+    reference_text: Optional[str] = None,
+    window_size: int = 4,
+    include_report: bool = True,
+    include_comparability: bool = True,
+    language_code: Optional[str] = None,
+) -> DataGenerationBundle:
+    model = PhoneticTrailingSongModel()
+    return model.prepare_data_generation(
+        text,
+        title=title,
+        reference_text=reference_text,
+        window_size=window_size,
+        include_report=include_report,
+        include_comparability=include_comparability,
+        language_code=language_code,
+    )
+
+
+# ----------------------------------------------------------------------
+# Command line interface
+
+def _load_text_argument(path_or_dash: str) -> str:
+    if path_or_dash == "-":
+        return sys.stdin.read()
+    return Path(path_or_dash).read_text(encoding="utf-8")
+
+
+def _emit_json(data: Dict[str, object]) -> None:
+    json.dump(data, sys.stdout, ensure_ascii=False, indent=2)
+    sys.stdout.write("\n")
+
+
+def _parse_args(argv: Optional[Sequence[str]] = None) -> argparse.Namespace:
+    parser = argparse.ArgumentParser(description="Phonetic trailing song analyzer")
+    parser.add_argument("text", help="Path to the text file or '-' for stdin")
+    parser.add_argument("--title", help="Optional analysis title")
+    parser.add_argument("--seed-from", dest="seed_from", help="Seed marker derived from supplied string")
+    parser.add_argument("--select-token", type=int, help="Show slider data for the given token index")
+    parser.add_argument("--compare-with", dest="compare_with", help="Reference text for comparability")
+    parser.add_argument("--compare-window-size", type=int, default=4, help="Sliding window size for comparisons")
+    parser.add_argument("--no-report", action="store_true", help="Suppress textual report output")
+    parser.add_argument("--emit-json", action="store_true", help="Emit the analysis as JSON")
+    parser.add_argument("--emit-data-bundle", metavar="PATH", help="Write a data generation bundle to PATH")
+    parser.add_argument("--reference-title", help="Optional title for the reference analysis")
+    parser.add_argument(
+        "--language-code",
+        help="Force a specific language profile (defaults to auto-detection)",
+    )
+    parser.add_argument(
+        "--list-languages",
+        action="store_true",
+        help="List available language profile codes and exit",
+    )
+    return parser.parse_args(argv)
+
+
+def _main(argv: Optional[Sequence[str]] = None) -> int:
+    args = _parse_args(argv)
+    model = PhoneticTrailingSongModel()
+
+    if args.list_languages:
+        for profile in model.language_registry.list_profiles():
+            print(f"{profile.code}\t{profile.name} - {profile.description}")
+        return 0
+
+    text = _load_text_argument(args.text)
+    reference_text = _load_text_argument(args.compare_with) if args.compare_with else None
+
+    analysis = model.analyze(
+        text,
+        title=args.title,
+        reference_text=reference_text,
+        seed_from=args.seed_from,
+        window_size=args.compare_window_size,
+        compare=bool(reference_text),
+        language_code=args.language_code,
+    )
+
+    if args.select_token is not None:
+        selected = next((seed for seed in analysis.token_seeds if seed.token_index == args.select_token), None)
+        if selected:
+            print(f"Token {selected.token_index}: seed={selected.base_seed} {selected.slider}")
+            codex_entry = next(
+                (entry for entry in analysis.read_aloud_codex if entry.token_index == args.select_token),
+                None,
+            )
+            if codex_entry:
+                beats = ", ".join(
+                    f"#{beat.syllable_index}:{beat.syllable}:{beat.intensity}/{beat.dim_level}"
+                    for beat in codex_entry.beats
+                )
+                print(f"  Read aloud beats -> {beats}")
+        else:
+            print(f"Token {args.select_token} not found", file=sys.stderr)
+
+    if not args.no_report:
+        report = model.build_report(analysis)
+        print(report)
+    else:
+        report = None
+
+    if args.emit_json:
+        _emit_json(analysis.as_dict())
+
+    if args.emit_data_bundle:
+        bundle = model.prepare_data_generation(
+            text,
+            title=args.title,
+            reference_text=reference_text,
+            window_size=args.compare_window_size,
+            include_report=not args.no_report,
+            include_comparability=bool(reference_text),
+            language_code=args.language_code,
+        )
+        Path(args.emit_data_bundle).write_text(
+            json.dumps(bundle.as_dict(), ensure_ascii=False, indent=2),
+            encoding="utf-8",
+        )
+
+    return 0
+
+
+if __name__ == "__main__":  # pragma: no cover
+    raise SystemExit(_main())

--- a/phonetic_trailing_song_model.py
+++ b/phonetic_trailing_song_model.py
@@ -524,6 +524,7 @@ class PhoneticTrailingSongModel:
         window_size: int = 4,
         compare: bool = False,
         language_code: Optional[str] = None,
+        exclude_languages: Optional[Sequence[str]] = None,
     ) -> AnalysisResult:
         base_profile, detection_notes = self.language_registry.detect(
             text,
@@ -533,10 +534,11 @@ class PhoneticTrailingSongModel:
         allow_mixed = language_code is None
         detection_notes["allow_mixed"] = allow_mixed
 
-        tokens, usage_counts = self._tokenize(
+        tokens, usage_counts, excluded_hits = self._tokenize(
             text,
             base_profile=base_profile,
             allow_mixed=allow_mixed,
+            excluded_languages=exclude_languages,
         )
         language_usage = self._summarize_language_usage(usage_counts)
         title_summaries = self._build_title_sound_summaries(text, tokens)
@@ -573,6 +575,13 @@ class PhoneticTrailingSongModel:
             "base_seed": self.base_seed,
             "language_detection": detection_notes,
         }
+
+        requested_exclusions = sorted({code.lower() for code in exclude_languages or []})
+        if requested_exclusions:
+            notes["language_exclusions"] = {
+                "requested": requested_exclusions,
+                "encountered": excluded_hits,
+            }
 
         if compare and reference_text:
             comparability = self.compare_texts(text, reference_text, window_size=window_size)
@@ -627,12 +636,12 @@ class PhoneticTrailingSongModel:
             reference_text,
             fallback=self.default_language_code,
         )
-        current_tokens, _ = self._tokenize(
+        current_tokens, _, _ = self._tokenize(
             current_text,
             base_profile=current_profile,
             allow_mixed=True,
         )
-        reference_tokens, _ = self._tokenize(
+        reference_tokens, _, _ = self._tokenize(
             reference_text,
             base_profile=reference_profile,
             allow_mixed=True,
@@ -692,9 +701,12 @@ class PhoneticTrailingSongModel:
         *,
         base_profile: LanguageProfile,
         allow_mixed: bool,
-    ) -> Tuple[List[PhoneticToken], Dict[str, int]]:
+        excluded_languages: Optional[Sequence[str]] = None,
+    ) -> Tuple[List[PhoneticToken], Dict[str, int], Dict[str, int]]:
         tokens: List[PhoneticToken] = []
         usage: Dict[str, int] = {}
+        excluded_hits: Dict[str, int] = {}
+        excluded_set = {code.lower() for code in excluded_languages or []}
         for index, match in enumerate(_WORD_RE.finditer(text)):
             raw = match.group(0)
             if allow_mixed:
@@ -704,6 +716,13 @@ class PhoneticTrailingSongModel:
                     fallback=base_profile.code,
                 )
             else:
+                profile = base_profile
+
+            original_code = profile.code
+            excluded_language = None
+            if original_code.lower() in excluded_set:
+                excluded_language = original_code
+                excluded_hits[original_code] = excluded_hits.get(original_code, 0) + 1
                 profile = base_profile
 
             romanized = profile.romanize(raw)
@@ -728,6 +747,8 @@ class PhoneticTrailingSongModel:
                     LanguageLayer("language_name", profile.name),
                 ],
             )
+            if excluded_language:
+                layers.layers.append(LanguageLayer("excluded_language", excluded_language))
             tokens.append(
                 PhoneticToken(
                     index=index,
@@ -746,7 +767,7 @@ class PhoneticTrailingSongModel:
                 )
             )
             usage[profile.code] = usage.get(profile.code, 0) + 1
-        return tokens, usage
+        return tokens, usage, excluded_hits
 
     def _build_title_sound_summaries(
         self, text: str, tokens: Sequence[PhoneticToken]
@@ -1282,6 +1303,7 @@ class PhoneticTrailingSongModel:
         include_report: bool = True,
         include_comparability: bool = True,
         language_code: Optional[str] = None,
+        exclude_languages: Optional[Sequence[str]] = None,
     ) -> DataGenerationBundle:
         analysis = self.analyze(
             text,
@@ -1291,6 +1313,7 @@ class PhoneticTrailingSongModel:
             window_size=window_size,
             compare=bool(reference_text and include_comparability),
             language_code=language_code,
+            exclude_languages=exclude_languages,
         )
         report = self.build_report(analysis, include_comparability=include_comparability) if include_report else None
         comparability_dict = (
@@ -1359,6 +1382,7 @@ def analyze_text(
     reference_text: Optional[str] = None,
     window_size: int = 4,
     language_code: Optional[str] = None,
+    exclude_languages: Optional[Sequence[str]] = None,
 ) -> AnalysisResult:
     model = PhoneticTrailingSongModel()
     return model.analyze(
@@ -1368,6 +1392,7 @@ def analyze_text(
         window_size=window_size,
         compare=bool(reference_text),
         language_code=language_code,
+        exclude_languages=exclude_languages,
     )
 
 
@@ -1380,6 +1405,7 @@ def prepare_data_generation(
     include_report: bool = True,
     include_comparability: bool = True,
     language_code: Optional[str] = None,
+    exclude_languages: Optional[Sequence[str]] = None,
 ) -> DataGenerationBundle:
     model = PhoneticTrailingSongModel()
     return model.prepare_data_generation(
@@ -1390,6 +1416,7 @@ def prepare_data_generation(
         include_report=include_report,
         include_comparability=include_comparability,
         language_code=language_code,
+        exclude_languages=exclude_languages,
     )
 
 
@@ -1424,6 +1451,12 @@ def _parse_args(argv: Optional[Sequence[str]] = None) -> argparse.Namespace:
         help="Force a specific language profile (defaults to auto-detection)",
     )
     parser.add_argument(
+        "--exclude-language",
+        action="append",
+        dest="exclude_languages",
+        help="Exclude specific language codes (e.g. lin-a, lin-b) and fall back to the default",
+    )
+    parser.add_argument(
         "--list-languages",
         action="store_true",
         help="List available language profile codes and exit",
@@ -1451,6 +1484,7 @@ def _main(argv: Optional[Sequence[str]] = None) -> int:
         window_size=args.compare_window_size,
         compare=bool(reference_text),
         language_code=args.language_code,
+        exclude_languages=args.exclude_languages,
     )
 
     if args.select_token is not None:
@@ -1488,6 +1522,7 @@ def _main(argv: Optional[Sequence[str]] = None) -> int:
             include_report=not args.no_report,
             include_comparability=bool(reference_text),
             language_code=args.language_code,
+            exclude_languages=args.exclude_languages,
         )
         Path(args.emit_data_bundle).write_text(
             json.dumps(bundle.as_dict(), ensure_ascii=False, indent=2),

--- a/repo_chunk_planner.py
+++ b/repo_chunk_planner.py
@@ -1,0 +1,218 @@
+"""Repository chunk planner utility.
+
+This tool helps contributors carve large corpora into approximately
+`chunk_size`-sized windows.  It collects file statistics, guarantees that each
+chunk is contiguous, and records filler segments when the natural file coverage
+would otherwise leave holes.
+"""
+
+from __future__ import annotations
+
+import argparse
+import fnmatch
+import json
+from dataclasses import dataclass
+from pathlib import Path
+from typing import Dict, Iterable, List, Optional, Sequence
+
+
+@dataclass
+class FileStat:
+    path: str
+    line_count: int
+
+    def as_dict(self) -> Dict[str, object]:
+        return {"path": self.path, "line_count": self.line_count}
+
+
+@dataclass
+class Chunk:
+    index: int
+    file: str
+    start_line: int
+    end_line: int
+    preview: str
+    filler: bool = False
+
+    def as_dict(self) -> Dict[str, object]:
+        return {
+            "index": self.index,
+            "file": self.file,
+            "start_line": self.start_line,
+            "end_line": self.end_line,
+            "preview": self.preview,
+            "filler": self.filler,
+        }
+
+
+@dataclass
+class ChunkPlan:
+    root: str
+    chunk_size: int
+    chunks: List[Chunk]
+    file_stats: List[FileStat]
+
+    def filler_statistics(self) -> Dict[str, int]:
+        filler_chunks = [chunk for chunk in self.chunks if chunk.filler]
+        return {
+            "total_chunks": len(self.chunks),
+            "filler_chunks": len(filler_chunks),
+        }
+
+    def as_dict(self) -> Dict[str, object]:
+        return {
+            "root": self.root,
+            "chunk_size": self.chunk_size,
+            "chunks": [chunk.as_dict() for chunk in self.chunks],
+            "file_stats": [stat.as_dict() for stat in self.file_stats],
+            "filler_statistics": self.filler_statistics(),
+        }
+
+
+def iter_matching_files(
+    root: Path,
+    includes: Sequence[str],
+    excludes: Sequence[str],
+) -> Iterable[Path]:
+    for path in root.rglob("*"):
+        if not path.is_file():
+            continue
+        relative = path.relative_to(root)
+        if includes and not any(fnmatch.fnmatch(str(relative), pattern) for pattern in includes):
+            continue
+        if excludes and any(fnmatch.fnmatch(str(relative), pattern) for pattern in excludes):
+            continue
+        yield path
+
+
+def count_lines(path: Path) -> int:
+    try:
+        return sum(1 for _ in path.open("r", encoding="utf-8", errors="ignore"))
+    except OSError:
+        return 0
+
+
+def build_chunk_plan(
+    root: Path,
+    *,
+    chunk_size: int,
+    includes: Sequence[str],
+    excludes: Sequence[str],
+    preview_lines: int,
+) -> ChunkPlan:
+    chunks: List[Chunk] = []
+    file_stats: List[FileStat] = []
+
+    matched_files = list(iter_matching_files(root, includes, excludes))
+    if not matched_files:
+        chunks.append(
+            Chunk(
+                index=0,
+                file="(no matches)",
+                start_line=0,
+                end_line=chunk_size,
+                preview="",
+                filler=True,
+            )
+        )
+        return ChunkPlan(root=str(root), chunk_size=chunk_size, chunks=chunks, file_stats=[])
+
+    chunk_index = 0
+    for file_path in matched_files:
+        lines = file_path.read_text(encoding="utf-8", errors="ignore").splitlines()
+        file_stats.append(FileStat(path=str(file_path.relative_to(root)), line_count=len(lines)))
+        if not lines:
+            chunks.append(
+                Chunk(
+                    index=chunk_index,
+                    file=str(file_path.relative_to(root)),
+                    start_line=1,
+                    end_line=1,
+                    preview="",
+                    filler=True,
+                )
+            )
+            chunk_index += 1
+            continue
+        for start in range(0, len(lines), chunk_size):
+            end = min(len(lines), start + chunk_size)
+            preview = "\n".join(lines[start : min(end, start + preview_lines)]) if preview_lines else ""
+            chunks.append(
+                Chunk(
+                    index=chunk_index,
+                    file=str(file_path.relative_to(root)),
+                    start_line=start + 1,
+                    end_line=end,
+                    preview=preview,
+                    filler=False,
+                )
+            )
+            chunk_index += 1
+        remainder = len(lines) % chunk_size
+        if remainder and remainder < chunk_size // 2:
+            filler_preview = lines[-preview_lines:] if preview_lines else []
+            chunks.append(
+                Chunk(
+                    index=chunk_index,
+                    file=str(file_path.relative_to(root)),
+                    start_line=len(lines) + 1,
+                    end_line=len(lines) + (chunk_size - remainder),
+                    preview="\n".join(filler_preview),
+                    filler=True,
+                )
+            )
+            chunk_index += 1
+
+    return ChunkPlan(
+        root=str(root),
+        chunk_size=chunk_size,
+        chunks=chunks,
+        file_stats=file_stats,
+    )
+
+
+def _parse_args(argv: Optional[Sequence[str]] = None) -> argparse.Namespace:
+    parser = argparse.ArgumentParser(description="Generate chunk plans for a repository")
+    parser.add_argument("root", nargs="?", default=".", help="Root directory")
+    parser.add_argument("--chunk-size", type=int, default=3000, help="Target number of lines per chunk")
+    parser.add_argument("--include", action="append", default=[], help="Glob of files to include")
+    parser.add_argument("--exclude", action="append", default=[], help="Glob of files to exclude")
+    parser.add_argument("--preview-lines", type=int, default=5, help="Number of preview lines to display")
+    parser.add_argument("--export-json", help="Write the chunk plan to this JSON file")
+    parser.add_argument("--quiet", action="store_true", help="Suppress chunk listing")
+    return parser.parse_args(argv)
+
+
+def _main(argv: Optional[Sequence[str]] = None) -> int:
+    args = _parse_args(argv)
+    root = Path(args.root).resolve()
+    plan = build_chunk_plan(
+        root,
+        chunk_size=args.chunk_size,
+        includes=args.include,
+        excludes=args.exclude,
+        preview_lines=args.preview_lines,
+    )
+
+    if not args.quiet:
+        print(f"Chunk plan for {plan.root} (chunk size {plan.chunk_size})")
+        for chunk in plan.chunks:
+            status = "FILL" if chunk.filler else "DATA"
+            print(
+                f"[{chunk.index:04d}] {status} {chunk.file}:{chunk.start_line}-{chunk.end_line}"
+                + (f" -> {chunk.preview.splitlines()[0]}" if chunk.preview else "")
+            )
+        stats = plan.filler_statistics()
+        print(f"Total chunks: {stats['total_chunks']} | filler: {stats['filler_chunks']}")
+
+    if args.export_json:
+        Path(args.export_json).write_text(
+            json.dumps(plan.as_dict(), ensure_ascii=False, indent=2),
+            encoding="utf-8",
+        )
+
+    return 0
+
+
+if __name__ == "__main__":  # pragma: no cover
+    raise SystemExit(_main())


### PR DESCRIPTION
## Summary
- derive syllable-aware read-aloud codex entries with deterministic intensities and dimmable sliders during analysis
- expose the codex through the CLI, JSON output, and HTTP metadata capabilities for cold-start narration workflows
- document the read-aloud feature in the README so users can discover the new API surface

## Testing
- python -m compileall phonetic_trailing_song_model.py phonetic_api.py language_profiles.py
- python phonetic_trailing_song_model.py --no-report --emit-json - <<'EOF'
Amazing grace how sweet the sound
EOF

------
https://chatgpt.com/codex/tasks/task_e_68dd931382d88323a709877be85a7993